### PR TITLE
Added babel preset preloading

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,23 @@
 const babel = require("babel-core").transform
 const assign = require("object-assign")
+const readPkg = require("read-pkg-up")
+const BABEL_REGEX = /(babel-preset)-([a-z0-9_-]+)/ig;
 
 module.exports = function () {
+  var cache
   return this.filter("babel", function (data, options) {
+    if (options.preload) {
+      var pkg = cache || readPkg.sync().pkg
+      var deps = pkg.devDependencies || {}
+      var presets = Object.keys(deps).reduce(function (acc, value) {
+        var processed = BABEL_REGEX.exec(value)
+        if (!processed) return acc
+        acc.push(processed[2])
+        return acc
+      }, [])
+      options.presets = presets
+      delete options.preload
+    }
     options.filename = options.file.base
     delete options.file
     return assign({ ext: ".js"}, babel(data.toString(), options))

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const babel = require("babel-core").transform
 const assign = require("object-assign")
 const readPkg = require("read-pkg-up")
-const BABEL_REGEX = /(babel-preset)-([a-z0-9_-]+)/ig;
+const BABEL_REGEX = /(^babel-preset)-(.*)/ig
 
 module.exports = function () {
   var cache
   return this.filter("babel", function (data, options) {
     if (options.preload) {
-      var pkg = cache || readPkg.sync().pkg
+      var pkg = cache || (cache = readPkg.sync().pkg)
       var deps = pkg.devDependencies || {}
       var presets = Object.keys(deps).reduce(function (acc, value) {
         var processed = BABEL_REGEX.exec(value)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.3.0",
     "babel-preset-es2015": "^6.3.0",
     "object-assign": "^3.0.0",
+    "read-pkg-up": "^1.0.1",
     "source-map": "^0.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I think it is nice feature to have preloading of presets, based on parsing devDependencies.
So basically:
```javascript
x.babel = function* () {
  yield this.source(file)
       .babel({ preload: true })
       .target(dist)
}
```

will parse `devDependencies`, find `babel` presets by regex and include them as available presets.
In this way we know that we have only one source of truth and we did not forget to include some presets

cc @bucaran @lukeed 